### PR TITLE
fix(mvk): resumeLostDevice

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/MoltenVK/MVKInitialization.cs
+++ b/src/Ryujinx.Graphics.Vulkan/MoltenVK/MVKInitialization.cs
@@ -25,6 +25,8 @@ namespace Ryujinx.Graphics.Vulkan.MoltenVK
             config.SemaphoreSupportStyle = MVKVkSemaphoreSupportStyle.MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_SINGLE_QUEUE;
             config.SynchronousQueueSubmits = false;
 
+            config.ResumeLostDevice = true;
+
             vkSetMoltenVKConfigurationMVK(IntPtr.Zero, config, configSize);
         }
     }


### PR DESCRIPTION
Command buffer errors currently trigger an exception "DeviceLost" crashing the process.

Looking at [MKV's code](https://github.com/KhronosGroup/MoltenVK/blob/53a4eb26f2fbd7322eb087eb4af263fe466543b0/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm#L392-L408) we observe that:
- It hard fails if error is: ``` MTLCommandBufferErrorBlacklisted || MTLCommandBufferErrorNotPermitted || MTLCommandBufferErrorDeviceRemoved ```
- Otherwise fails conditionally if `config.resumeLostDevice == false` (current default)

For Ryujinx's use-case it's more graceful to resume on those errors rather than crashing the app, the error isn't totally silenced since `mvk` still logs it

Fixes #4704, #4575